### PR TITLE
Update Node pod CIDR in ipam controller for for Multi Pod CIDR suppor…

### DIFF
--- a/pkg/controller/nodeipam/ipam/BUILD
+++ b/pkg/controller/nodeipam/ipam/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//pkg/controller/nodeipam/ipam/cidrset",
         "//pkg/controller/nodeipam/ipam/test",
         "//pkg/controller/testutil",
+        "//pkg/util/node",
         "//providers/gce",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta",
         "//vendor/github.com/google/go-cmp/cmp",

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -40,6 +40,7 @@ import (
 	clSetFake "k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned/fake"
 	networkinformers "k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions"
 	"k8s.io/cloud-provider-gcp/pkg/controller/testutil"
+	utilnode "k8s.io/cloud-provider-gcp/pkg/util/node"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	metricsUtil "k8s.io/component-base/metrics/testutil"
 )
@@ -490,6 +491,64 @@ func TestUpdateCIDRAllocation(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test",
+						},
+						Spec: v1.NodeSpec{
+							ProviderID: "gce://test-project/us-central1-b/test",
+						},
+						Status: v1.NodeStatus{
+							Capacity: v1.ResourceList{},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(),
+			},
+			gceInstance: []*compute.Instance{
+				{
+					Name: "test",
+					NetworkInterfaces: []*compute.NetworkInterface{
+						interfaces(defaultVPCName, defaultVPCSubnetName, "80.1.172.1", []*compute.AliasIpRange{
+							{IpCidrRange: "192.168.1.0/24", SubnetworkRangeName: defaultSecondaryRangeA},
+							{IpCidrRange: "10.11.1.0/24", SubnetworkRangeName: defaultSecondaryRangeB},
+						}),
+					},
+				},
+			},
+			nodeChanges: func(node *v1.Node) {
+				node.Spec.PodCIDR = "192.168.1.0/24"
+				node.Spec.PodCIDRs = []string{"192.168.1.0/24"}
+				node.Status.Conditions = []v1.NodeCondition{
+					{
+						Type:    "NetworkUnavailable",
+						Status:  "False",
+						Reason:  "RouteCreated",
+						Message: "NodeController create implicit route",
+					},
+				}
+				node.Annotations = map[string]string{
+					networkv1.NorthInterfacesAnnotationKey: "[]",
+					networkv1.MultiNetworkAnnotationKey:    "[]",
+				}
+			},
+			expectedUpdate:  true,
+			expectedMetrics: map[string]float64{},
+		},
+		{
+			name: "[mn] default network only, get PodCIDR with node labels",
+			networks: []*networkv1.Network{
+				network(networkv1.DefaultPodNetworkName, defaultGKENetworkParamsName, false),
+			},
+			gkeNwParams: []*networkv1.GKENetworkParamSet{
+				gkeNetworkParams(defaultGKENetworkParamsName, defaultVPCName, defaultVPCSubnetName, nil),
+			},
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+							Labels: map[string]string{
+								utilnode.NodePoolSubnetLabelPrefix:   "default",
+								utilnode.NodePoolPodRangeLabelPrefix: defaultSecondaryRangeA,
+							},
 						},
 						Spec: v1.NodeSpec{
 							ProviderID: "gce://test-project/us-central1-b/test",

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	networkv1 "k8s.io/cloud-provider-gcp/crd/apis/network/v1"
+	utilnode "k8s.io/cloud-provider-gcp/pkg/util/node"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 )
@@ -18,11 +19,11 @@ import (
 // performMultiNetworkCIDRAllocation receives the existing Node object and its
 // GCE interfaces, and is updated with the corresponding annotations for
 // MultiNetwork and NorthInterfaces and the capacity for the additional networks.
-// It also returns calculated cidrs for default Network.
+// It also returns calculated cidrs for default Network if there're no node labels.
 //
 // NorthInterfacesAnnotationKey is modified on Network Ready condition changes.
 // MultiNetworkAnnotationKey is modified on Node's NodeNetworkAnnotationKey changes.
-func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, interfaces []*compute.NetworkInterface) (defaultNwCIDRs []string, err error) {
+func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, interfaces []*compute.NetworkInterface, hasNodeLabels bool) (defaultNwCIDRs []string, err error) {
 	northInterfaces := networkv1.NorthInterfacesAnnotation{}
 	additionalNodeNetworks := networkv1.MultiNetworkAnnotation{}
 
@@ -96,13 +97,15 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 				}
 				klog.V(2).InfoS("found an allocatable secondary range for the interface on network", "nodeName", node.Name, "networkName", network.Name)
 				processedNetworks[network.Name] = struct{}{}
-				if networkv1.IsDefaultNetwork(network.Name) {
+				// for defaultNwCIDRs, if there're no NodeLabels keep this; otherwise skip it
+				if networkv1.IsDefaultNetwork(network.Name) && !hasNodeLabels {
 					defaultNwCIDRs = append(defaultNwCIDRs, ipRange.IpCidrRange)
 					ipv6Addr := ca.cloud.GetIPV6Address(inf)
 					if ipv6Addr != nil {
 						defaultNwCIDRs = append(defaultNwCIDRs, ipv6Addr.String())
 					}
-				} else {
+				}
+				if !networkv1.IsDefaultNetwork(network.Name) {
 					northInterfaces = append(northInterfaces, networkv1.NorthInterface{Network: network.Name, IpAddress: inf.NetworkIP})
 					if _, ok := upStatusNetworks[network.Name]; ok {
 						additionalNodeNetworks = append(additionalNodeNetworks, networkv1.NodeNetwork{Name: network.Name, Scope: "host-local", Cidrs: []string{ipRange.IpCidrRange}})
@@ -116,6 +119,42 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 		return nil, err
 	}
 	return defaultNwCIDRs, nil
+}
+
+// getNodeDefaultLabels returns true if the node has labels for subnet and Pod range
+func getNodeDefaultLabels(node *v1.Node) (bool, string, string) {
+	defaultSubnet, foundSubnet := node.Labels[utilnode.NodePoolSubnetLabelPrefix]
+	defaultPodRange, foundRange := node.Labels[utilnode.NodePoolPodRangeLabelPrefix]
+	if !foundSubnet || defaultSubnet == "" || !foundRange || defaultPodRange == "" {
+		return false, "", ""
+	}
+	return true, defaultSubnet, defaultPodRange
+}
+
+// getDefaultNwCIDRs returns the Pod CIDRs for default Network.
+// Different subnet can have the same secondary range name, here uses the subnet and range name
+// to find the matching CIDR(s)
+func (ca *cloudCIDRAllocator) getDefaultNwCIDRs(node *v1.Node, interfaces []*compute.NetworkInterface, defaultSubnet, defaultPodRange string) (defaultNwCIDRs []string) {
+out:
+	for _, inf := range interfaces {
+		// extra the subnetwork name from the URL
+		parts := strings.Split(inf.Subnetwork, "/subnetworks/")
+		if parts[1] != defaultSubnet {
+			continue
+		}
+		for _, ipRange := range inf.AliasIpRanges {
+			if ipRange.SubnetworkRangeName != defaultPodRange {
+				continue
+			}
+			defaultNwCIDRs = append(defaultNwCIDRs, ipRange.IpCidrRange)
+			ipv6Addr := ca.cloud.GetIPV6Address(inf)
+			if ipv6Addr != nil {
+				defaultNwCIDRs = append(defaultNwCIDRs, ipv6Addr.String())
+			}
+			break out
+		}
+	}
+	return defaultNwCIDRs
 }
 
 func updateAnnotations(node *v1.Node, northInterfaces networkv1.NorthInterfacesAnnotation, additionalNodeNetworks networkv1.MultiNetworkAnnotation) error {

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -35,6 +35,9 @@ const (
 	// NodePoolPodRangeLabelPrefix is the prefix for the default Pod range
 	// name for the node and it can be different with cluster Pod range
 	NodePoolPodRangeLabelPrefix = "cloud.google.com/gke-np-default-pod-range"
+	// NodePoolSubnetLabelPrefix is the prefix for the default subnet
+	// name for the node
+	NodePoolSubnetLabelPrefix = "cloud.google.com/gke-np-default-subnet"
 )
 
 type nodeForConditionPatch struct {


### PR DESCRIPTION
…t with Multi Networking. This PR is after https://github.com/kubernetes/cloud-provider-gcp/pull/638

Depends on whether the node has label for subnet and Pod range:
  - if no label, node ipam controller keeps the old way to compare default GNP and Network to get the default CIDRs for the node
  - if label exists, node ipam controller use the labels to get the default CIDRs, it will update the node.Spec.PodCIDR then continue to perform the rest node annotations update